### PR TITLE
Remove leaks, hints and fix bug on iOS file selector

### DIFF
--- a/Core/DW.UIHelper.Android.pas
+++ b/Core/DW.UIHelper.Android.pas
@@ -46,7 +46,7 @@ uses
   // RTL
   System.SysUtils,
   // Android
-  Androidapi.Helpers, Androidapi.JNI.GraphicsContentViewText,
+  Androidapi.Helpers, Androidapi.JNI.GraphicsContentViewText, Androidapi.JNI.App,
   // FMX
   FMX.Platform.UI.Android;
 

--- a/Features/Connectivity/DW.Connectivity.Android.pas
+++ b/Features/Connectivity/DW.Connectivity.Android.pas
@@ -84,7 +84,7 @@ uses
   DW.OSLog,
   System.SysUtils,
   // Android
-  Androidapi.JNI.JavaTypes, Androidapi.Helpers, Androidapi.JNI.Os;
+  Androidapi.JNI.JavaTypes, Androidapi.Helpers, Androidapi.JNI.Os, Androidapi.JNI;
 
 type
   TOpenConnectivity = class(TConnectivity);

--- a/Features/Connectivity/DW.Connectivity.Win.pas
+++ b/Features/Connectivity/DW.Connectivity.Win.pas
@@ -45,6 +45,7 @@ type
   private
     class var FCurrent: TNetwork;
     class constructor CreateClass;
+    class destructor DestroyClass;
   private
     FConnectivity: TConnectivity;
     FCookie: Longint;
@@ -210,6 +211,11 @@ begin
   FNetworkListManager := nil;
   CoUninitialize;
   inherited;
+end;
+
+class destructor TNetwork.DestroyClass;
+begin
+  FCurrent.Free;
 end;
 
 procedure TNetwork.SetConnectivity(const Value: TConnectivity);

--- a/Features/FilesSelector/DW.FilesSelector.Android.pas
+++ b/Features/FilesSelector/DW.FilesSelector.Android.pas
@@ -17,7 +17,7 @@ interface
 
 uses
   // RTL
-  System.Messaging, System.Classes,
+  System.Messaging, System.Classes, System.SysUtils,
   // Android
   Androidapi.JNI.GraphicsContentViewText, Androidapi.JNI.Net,
   // FMX
@@ -86,8 +86,6 @@ end;
 
 procedure TPlatformFilesSelector.HandleSelectorOK(const AData: JIntent);
 var
-  LURI: Jnet_Uri;
-  LFileName: string;
   I: Integer;
 begin
   if AData.getClipData <> nil then

--- a/Features/FilesSelector/DW.FilesSelector.iOS.pas
+++ b/Features/FilesSelector/DW.FilesSelector.iOS.pas
@@ -6,7 +6,7 @@ unit DW.FilesSelector.iOS;
 {                                                       }
 {         Delphi Worlds Cross-Platform Library          }
 {                                                       }
-{    Copyright 2020 Dave Nottage under MIT license      }
+{  Copyright 2020-2021 Dave Nottage under MIT license   }
 {  which is located in the root folder of this library  }
 {                                                       }
 {*******************************************************}
@@ -138,7 +138,7 @@ begin
   FSelector.FileTypes.Add('public.source-code');
   DestroyController;
   FController := TUIDocumentPickerViewController.Alloc;
-  FController := TUIDocumentPickerViewController.Wrap(FController.initWithDocumentTypes(StringsToNSArray(FSelector.FileTypes), UIDocumentPickerModeOpen));
+  FController := TUIDocumentPickerViewController.Wrap(FController.initWithDocumentTypes(StringsToNSArray(FSelector.FileTypes), UIDocumentPickerModeImport));
   FController.setDelegate(GetObjectID);
   FController.setTitle(StrToNSStr(FSelector.Title));
   TiOSHelper.SharedApplication.keyWindow.rootViewController.presentViewController(FController, True, nil);
@@ -153,9 +153,13 @@ end;
 procedure TUIDocumentPickerDelegate.documentPickerDidPickDocumentsAtURLs(controller: UIDocumentPickerViewController; urls: NSArray);
 var
   I: Integer;
+  LEscapedFileName: NSString;
 begin
   for I := 0 to urls.count - 1 do
-    FSelector.Files.Add(NSUrlToStr(TNSURL.Wrap(urls.objectAtIndex(I))));
+  begin
+    LEscapedFileName := TNSURL.Wrap(urls.objectAtIndex(I)).path.stringByReplacingPercentEscapesUsingEncoding(NSUTF8StringEncoding);
+    FSelector.Files.Add(NSStrToStr(LEscapedFileName));
+  end;
   FSelector.DoComplete(True);
 end;
 


### PR DESCRIPTION
Windows memory leak by TNetwork instance on DW.Connectivity.Win.

iOS file selector: That was a problem when tryed to load the file from stream. Resolved by Dave.

[DCC Hint] DW.FilesSelector.Android.pas(89): H2164 Variable 'LURI' is declared but never used in 'TPlatformFilesSelector.HandleSelectorOK'

[DCC Hint] DW.FilesSelector.Android.pas(90): H2164 Variable 'LFileName' is declared but never used in 'TPlatformFilesSelector.HandleSelectorOK'

[DCC Hint] DW.FilesSelector.Android.pas(122): H2443 Inline function 'TAndroidHelper.GetJActivity' has not been expanded because unit 'System.SysUtils' is not specified in USES list