### PR TITLE
Correct StartLocation

### DIFF
--- a/Demos/CrossPlatformLocation/Application/Views/CPL.View.Main.pas
+++ b/Demos/CrossPlatformLocation/Application/Views/CPL.View.Main.pas
@@ -157,9 +157,8 @@ begin
   inherited;
   {$IF Defined(ANDROID)}
   RequestPermissions;
-  {$ELSE}
-  StartLocation;
   {$ENDIF}
+  StartLocation;
 end;
 
 procedure TMainView.Resize;


### PR DESCRIPTION
Running CrossPlatformLocation Demo , StartLocation is not Running because it's excluded from{$IF Defined(ANDROID)}